### PR TITLE
修改首頁和課程分類搜尋框

### DIFF
--- a/assets/js/coursePage/search.js
+++ b/assets/js/coursePage/search.js
@@ -11,6 +11,7 @@ if (indexSearchInput) {
   data.q = indexSearchInput;
   getCoursesData(data);
   data.q = "";
+  localStorage.removeItem("indexSearchInput");
 }
 
 const courseSearchButton = document.querySelector(".course-search-button");
@@ -18,7 +19,6 @@ const courseSearchButton = document.querySelector(".course-search-button");
 courseSearchButton.addEventListener("click", function () {
   data.q = courseSearchInput.value;
   getCoursesData(data);
-  localStorage.removeItem("indexSearchInput");
 });
 
 courseSearchInput.addEventListener("keyup", function (e) {

--- a/assets/js/coursePage/search.js
+++ b/assets/js/coursePage/search.js
@@ -1,35 +1,35 @@
 import { data, getCoursesData } from "./api.js";
 
+/*** 取得 banner 搜尋框 ***/
+const courseSearchInput = document.querySelector(".course-search-input");
+
 /*** 首頁搜尋跳轉 ***/
 const indexSearchInput = localStorage.getItem("indexSearchInput");
 
 if (indexSearchInput) {
+  courseSearchInput.value = indexSearchInput;
   data.q = indexSearchInput;
   getCoursesData(data);
   data.q = "";
-  localStorage.removeItem("indexSearchInput");
 }
-
-/*** 取得 banner 搜尋框的值 ***/
-const courseSearchInput = document.querySelector(".course-search-input");
-
-let courseSearchInputValue = "";
-
-courseSearchInput.addEventListener("input", function () {
-  courseSearchInputValue = courseSearchInput.value;
-});
 
 const courseSearchButton = document.querySelector(".course-search-button");
 
 courseSearchButton.addEventListener("click", function () {
-  data.q = courseSearchInputValue;
+  data.q = courseSearchInput.value;
   getCoursesData(data);
-  courseSearchInput.value = "";
-  courseSearchInputValue = "";
+  localStorage.removeItem("indexSearchInput");
 });
 
 courseSearchInput.addEventListener("keyup", function (e) {
   if (e.key === "Enter") {
     courseSearchButton.click();
   }
+});
+
+// 清除輸入框
+const clearInputBtn = document.querySelector(".clear-input");
+
+clearInputBtn.addEventListener("click", function () {
+  courseSearchInput.value = "";
 });

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -29,25 +29,33 @@ bannerInputs.forEach((bannerInput) => {
   bannerInput.addEventListener("input", () => {
     bannerInputValue = bannerInput.value;
 
-    // 監聽搜尋按鈕
-    bannerSearchBtns.forEach((bannerSearchBtn) => {
-      bannerSearchBtn.addEventListener("click", () => {
-        //- 點擊按鈕後將 搜尋內容 放入 localStorage
-        localStorage.setItem("indexSearchInput", bannerInputValue);
-
-        // 清空首頁搜尋框
+    // 清除輸入框
+    const clearInputBtns = document.querySelectorAll(".clear-input");
+    clearInputBtns.forEach((clearInputBtn) => {
+      clearInputBtn.addEventListener("click", function () {
         bannerInput.value = "";
-
-        //- 跳轉 course.html
-        location.href = "./course.html";
-      });
-
-      document.addEventListener("keyup", function (e) {
-        if (e.key === "Enter") {
-          bannerSearchBtn.click();
-        }
+        bannerInputValue = bannerInput.value;
       });
     });
+  });
+});
+
+// 監聽搜尋按鈕
+bannerSearchBtns.forEach((bannerSearchBtn) => {
+  bannerSearchBtn.addEventListener("click", () => {
+    if (bannerInputValue) {
+      //- 點擊按鈕後將 搜尋內容 放入 localStorage
+      localStorage.setItem("indexSearchInput", bannerInputValue);
+
+      //- 跳轉 course.html
+      location.href = "./course.html";
+    }
+  });
+
+  document.addEventListener("keyup", function (e) {
+    if (e.key === "Enter") {
+      bannerSearchBtn.click();
+    }
   });
 });
 

--- a/pages/account.html
+++ b/pages/account.html
@@ -1470,9 +1470,7 @@
     <script type="module" src="../main.js"></script>
     <script type="module" src="../assets/js/openTime.js"></script>
     <script type="module" src="../assets/js/account_date.js"></script>
-    <script type="module" src="../assets/js/calendar.js"></script>
     <script type="module" src="../assets/js/appointment.js"></script>
-    <script type="module" src="../assets/js/time_course.js"></script>
     <script type="module" src="../assets/js/course_management.js"></script>
     <script type="module" src="../assets/js/patch_data.js"></script>
     <script>

--- a/pages/course.html
+++ b/pages/course.html
@@ -36,11 +36,14 @@
           <div class="input-group">
             <input
               type="text"
-              class="form-control border-light course-search-input"
+              class="form-control border-light course-search-input z-1"
               placeholder="今天想學什麼..."
               aria-label="search keywords"
               aria-describedby="button-addon2"
-            />
+            /><i
+              type="button"
+              class="fa-solid fa-xmark position-absolute top-50 end-0 translate-middle-y me-15 me-md-17 z-2 clear-input"
+            ></i>
             <button
               class="btn btn-secondary2 btn-search z-0 course-search-button"
               type="button"

--- a/pages/index.html
+++ b/pages/index.html
@@ -35,11 +35,15 @@
               <div class="input-group">
                 <input
                   type="text"
-                  class="form-control border-light banner-input"
+                  class="form-control border-light banner-input z-1"
                   placeholder="今天想學什麼..."
                   aria-label="search keywords"
                   aria-describedby="button-addon2"
                 />
+                <i
+                  type="button"
+                  class="fa-solid fa-xmark position-absolute top-50 end-0 translate-middle-y me-15 me-md-17 z-2 clear-input"
+                ></i>
                 <button
                   class="btn btn-secondary2 btn-search banner-btn-search"
                   type="button"
@@ -63,11 +67,14 @@
               <div class="input-group">
                 <input
                   type="text"
-                  class="form-control border-light banner-input"
+                  class="form-control border-light banner-input z-1"
                   placeholder="今天想學什麼..."
                   aria-label="search keywords"
                   aria-describedby="button-addon2"
-                />
+                /><i
+                  type="button"
+                  class="fa-solid fa-xmark position-absolute top-50 end-0 translate-middle-y me-15 me-md-17 z-2 clear-input"
+                ></i>
                 <button
                   class="btn btn-secondary2 btn-search banner-btn-search"
                   type="button"
@@ -91,11 +98,14 @@
               <div class="input-group">
                 <input
                   type="text"
-                  class="form-control border-light banner-input"
+                  class="form-control border-light banner-input z-1"
                   placeholder="今天想學什麼..."
                   aria-label="search keywords"
                   aria-describedby="button-addon2"
-                />
+                /><i
+                  type="button"
+                  class="fa-solid fa-xmark position-absolute top-50 end-0 translate-middle-y me-15 me-md-17 z-2 clear-input"
+                ></i>
                 <button
                   class="btn btn-secondary2 btn-search banner-btn-search"
                   type="button"


### PR DESCRIPTION
首頁**"三個"** banner
* 搜尋框都可以正常搜尋，跳轉課程分類，並顯示對應結果，課程分類的搜尋框會顯示剛剛首頁輸入的關鍵字。
* 點擊 x，清空搜尋框，點擊搜尋按鈕 (或 enter) 不會有反應

課程分類
* 搜尋框可以正常搜尋，關鍵字會留著
* 重整或是點擊 navbar 的課程分類按鈕 都會清空搜尋框 (33筆)
* 點擊 x，清空搜尋框，點擊搜尋按鈕 (或 enter) 會回到初始狀態 (33筆)
* 點擊 navbar 的課程分類按鈕，會回到初始狀態 (33筆)